### PR TITLE
修改chapter0.md的一点小错误

### DIFF
--- a/content/chapter0.md
+++ b/content/chapter0.md
@@ -57,7 +57,7 @@ pid = fork();
 if(pid > 0){
     printf("parent: child=%d\n", pid);
     pid = wait();
-    printf("child %d is done\n", pid);
+    printf("parent: child %d is done\n", pid);
 } else if(pid == 0){
     printf("child: exiting\n");
     exit();


### PR DESCRIPTION
下方有这个，所以需要修改一下代码：


可能以任意顺序被打印，这种顺序由父进程或子进程谁先结束 `printf` 决定。当子进程退出时，父进程的 `wait` 也就返回了，于是父进程打印：

~~~
parent: child 1234 is done
~~~

需要留意的是父子进程拥有不同的内存空间和寄存器，改变一个进程中的变量不会影响另一个进程。
